### PR TITLE
Add a composer.json.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,12 @@
+{
+  "name": "multi-safepay/presta-shop",
+  "description": "Prestashop 1.7 compatible MultiSafepay module\n",
+  "license": "AFL - Academic Free License (AFL 3.0)",
+  "require": {
+    "php": ">=5.6.0"
+  },
+  "config": {
+    "preferred-install": "dist"
+  },
+  "type": "prestashop-module"
+}

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
   "name": "multisafepay/prestashop",
-  "description": "Prestashop 1.7 compatible MultiSafepay module\n",
+  "description": "MultiSafepay module for PrestaShop 1.7",
   "license": "AFL - Academic Free License (AFL 3.0)",
   "require": {
     "php": ">=5.6.0"

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-  "name": "multi-safepay/presta-shop",
+  "name": "multisafepay/prestashop",
   "description": "Prestashop 1.7 compatible MultiSafepay module\n",
   "license": "AFL - Academic Free License (AFL 3.0)",
   "require": {


### PR DESCRIPTION
If i want to install this plugin with composer we cannot. To fix that you can add a composer.json.

In the composer.json we set the type to prestashop-module so it will be picked up by https://github.com/composer/installers on instalation.